### PR TITLE
Use app name along with the token when finding folders and registry keys to delete.

### DIFF
--- a/ClickOnceUninstaller/RemoveRegistryKeys.cs
+++ b/ClickOnceUninstaller/RemoveRegistryKeys.cs
@@ -62,25 +62,26 @@ namespace Wunder.ClickOnceUninstaller
             }
 
             var token = _uninstallInfo.GetPublicKeyToken();
+            var applicationAbbreviation = _uninstallInfo.GetApplicationNameAbbreviation();
 
             var packageMetadata = Registry.CurrentUser.OpenSubKey(PackageMetadataRegistryPath);
             foreach (var keyName in packageMetadata.GetSubKeyNames())
             {
-                DeleteMatchingSubKeys(PackageMetadataRegistryPath + "\\" + keyName, token);
+                DeleteMatchingSubKeys(PackageMetadataRegistryPath + "\\" + keyName, token, applicationAbbreviation);
             }
 
-            DeleteMatchingSubKeys(ApplicationsRegistryPath, token);
-            DeleteMatchingSubKeys(FamiliesRegistryPath, token);
-            DeleteMatchingSubKeys(VisibilityRegistryPath, token);
+            DeleteMatchingSubKeys(ApplicationsRegistryPath, token, applicationAbbreviation);
+            DeleteMatchingSubKeys(FamiliesRegistryPath, token, applicationAbbreviation);
+            DeleteMatchingSubKeys(VisibilityRegistryPath, token, applicationAbbreviation);
         }
 
-        private void DeleteMatchingSubKeys(string registryPath, string token)
+        private void DeleteMatchingSubKeys(string registryPath, string token, string applicationNameAbbreviation)
         {
             var key = Registry.CurrentUser.OpenSubKey(registryPath, true);
             _disposables.Add(key);
             foreach (var subKeyName in key.GetSubKeyNames())
             {
-                if (subKeyName.Contains(token))
+                if (subKeyName.IndexOf(string.Format("{0}_{1}", applicationNameAbbreviation, token), StringComparison.OrdinalIgnoreCase) >= 0)
                 {
                     _keysToRemove.Add(new RegistryMarker(key, subKeyName));
                 }

--- a/ClickOnceUninstaller/UninstallInfo.cs
+++ b/ClickOnceUninstaller/UninstallInfo.cs
@@ -59,5 +59,23 @@ namespace Wunder.ClickOnceUninstaller
             if (token.Length != 16) throw new ArgumentException();
             return token;
         }
+
+        public string GetApplicationName()
+        {
+            var name = UninstallString.Split(',').First(s => s.Trim().StartsWith("ShArpMaintain ")).Substring(14);
+            if (name.Length <= 0) throw new ArgumentException();
+            return name;
+        }
+
+        public string GetApplicationNameAbbreviation()
+        {
+            var appName = GetApplicationName();
+            if (appName.Length <= 10)
+            {
+                return appName;
+            }
+
+            return appName.Substring(0, 4) + ".." + appName.Substring(appName.Length - 4);
+        }
     }
 }

--- a/ClickOnceUninstaller/Uninstaller.cs
+++ b/ClickOnceUninstaller/Uninstaller.cs
@@ -20,7 +20,7 @@ namespace Wunder.ClickOnceUninstaller
 
         public void Uninstall(UninstallInfo uninstallInfo)
         {
-            var toRemove = FindComponentsToRemove(uninstallInfo.GetPublicKeyToken());
+            var toRemove = FindComponentsToRemove(uninstallInfo.GetPublicKeyToken(), uninstallInfo.GetApplicationNameAbbreviation());
 
             Console.WriteLine("Components to remove:");
             toRemove.ForEach(Console.WriteLine);
@@ -41,9 +41,9 @@ namespace Wunder.ClickOnceUninstaller
             steps.ForEach(s => s.Dispose());
         }
 
-        private List<string> FindComponentsToRemove(string token)
+        private List<string> FindComponentsToRemove(string token, string applicationNameAbbreviation)
         {
-            var components = _registry.Components.Where(c => c.Key.Contains(token)).ToList();
+            var components = _registry.Components.Where(c => c.Key.Contains(token) && c.Key.StartsWith(applicationNameAbbreviation, StringComparison.OrdinalIgnoreCase)).ToList();
 
             var toRemove = new List<string>();
             foreach (var component in components)


### PR DESCRIPTION
I had multiple click once applications that were published with the same token, 0000000000000000. When trying to uninstall one of them registry keys and folders for applications that weren't intended to be uninstalled were being deleted. This change uses the abbreviated application name as well as the token to find the correct folders and registry keys to delete.