### PR TITLE
Added ability to Find Installer By the Click Once URL path

### DIFF
--- a/ClickOnceUninstaller/UninstallInfo.cs
+++ b/ClickOnceUninstaller/UninstallInfo.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Linq;
 using Microsoft.Win32;
+using System.Text;
+using System.Security.Policy;
 
 namespace Wunder.ClickOnceUninstaller
 {
@@ -32,6 +34,54 @@ namespace Wunder.ClickOnceUninstaller
                                        SupportShortcutFileName = sub.GetValue("SupportShortcutFileName") as string,
                                        Version = sub.GetValue("DisplayVersion") as string
                                    };
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        public static string GetPublicKeyTokenFromAppDomain()
+        {
+            StringBuilder pkt = new StringBuilder();
+
+            ApplicationSecurityInfo asi = new ApplicationSecurityInfo(AppDomain.CurrentDomain.ActivationContext);
+            byte[] pk = asi.ApplicationId.PublicKeyToken;
+
+            for (int i = 0; i < pk.GetLength(0); i++)
+                pkt.Append(String.Format("{0:x}", pk[i]));
+
+            return pkt.ToString();
+        }
+
+        public static UninstallInfo FindByInstallerUrl(string urlName)
+        {
+            var publicKey = GetPublicKeyTokenFromAppDomain();
+
+            var uninstall = Registry.CurrentUser.OpenSubKey(UninstallRegistryPath);
+            if (uninstall != null)
+            {
+                foreach (var app in uninstall.GetSubKeyNames())
+                {
+                    var sub = uninstall.OpenSubKey(app);
+                    if (sub != null && sub.GetValue("UrlUpdateInfo") as string == urlName)
+                    {
+                        string tmpUninstallString = sub.GetValue("UninstallString").ToString();
+
+                        if (tmpUninstallString.Contains(publicKey) == true)
+                        {
+                            // found correct uninstall instance!
+                            return new UninstallInfo
+                            {
+                                Key = app,
+                                UninstallString = sub.GetValue("UninstallString") as string,
+                                ShortcutFolderName = sub.GetValue("ShortcutFolderName") as string,
+                                ShortcutSuiteName = sub.GetValue("ShortcutSuiteName") as string,
+                                ShortcutFileName = sub.GetValue("ShortcutFileName") as string,
+                                SupportShortcutFileName = sub.GetValue("SupportShortcutFileName") as string,
+                                Version = sub.GetValue("DisplayVersion") as string
+                            };
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Hi there.  Great project. Saved my bacon when migrating a Click Once App.  However, due to weirdness the application name wasn't always the same across the client machines. 

So I added a 2nd Find method named "FindByInstallerUrl".  To use it, you pass the ClickOnce URL. For example: "\\SomeServer\SomeClickOnceApp\AppName.application"

This works because there can only be one application installed at that location.  

This new helper method worked for me and the users that were having the problems successfully migrated to the new URL. 
