### PR TITLE
Exit Codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,5 @@ _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
 *.tmp_proj
+
+.vs/*

--- a/ClickOnceUninstaller/Program.cs
+++ b/ClickOnceUninstaller/Program.cs
@@ -5,28 +5,38 @@ namespace Wunder.ClickOnceUninstaller
     class Program
     {
 
-        static void Main(string[] args)
+        static int Main(string[] args)
         {
-            if (args.Length != 1 || string.IsNullOrEmpty(args[0]))
+            try
             {
-                Console.WriteLine("Usage:\nClickOnceUninstaller appName");
-                return;
+                if (args.Length != 1 || string.IsNullOrEmpty(args[0]))
+                {
+                    Console.WriteLine("Usage:\nClickOnceUninstaller appName");
+                    return 0;
+                }
+
+                var appName = args[0];
+
+                var uninstallInfo = UninstallInfo.Find(appName);
+                if (uninstallInfo == null)
+                {
+                    Console.WriteLine("Could not find application \"{0}\"", appName);
+                    return 1;
+                }
+
+                Console.WriteLine("Uninstalling application \"{0}\"", appName);
+                var uninstaller = new Uninstaller();
+                uninstaller.Uninstall(uninstallInfo);
+
+                Console.WriteLine("Uninstall complete");
+
+                return 0;
             }
-
-            var appName = args[0];
-
-            var uninstallInfo = UninstallInfo.Find(appName);
-            if (uninstallInfo == null)
+            catch(Exception ex)
             {
-                Console.WriteLine("Could not find application \"{0}\"", appName);
-                return;
+                Console.WriteLine(ex.Message);
+                return 2;
             }
-
-            Console.WriteLine("Uninstalling application \"{0}\"", appName);
-            var uninstaller = new Uninstaller();
-            uninstaller.Uninstall(uninstallInfo);
-
-            Console.WriteLine("Uninstall complete");
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ It automatically resolves dependencies between installed components and removes 
 
 The uninstaller can be used programmatically as .NET library, through a command line interface and as custom action for a WiX setup package. 
 
-The included custom action for WiX is based on the .NET Framework 3.0 which is already shipped with Windows Vista or higher. 
+The included custom action for WiX is based on the .NET Framework 3.0 which is already shipped with Windows Vista or higher.
+
+The uninstaller will return a variety of error codes:
+ - 0 : Success
+ - 1 : Application not found
+ - 2 : Unexpected error
 
 ### How?
 


### PR DESCRIPTION
To utilize this utility in scripts, an exit code is crucial to make decisions downstream.

 - [X] Changing return type of main method to `int`
 - [X] Returning integer based on program exit condition
 - [X] Updated `README.md`
 - [X] Updating `.gitignore` to ignore assets from newer Visual Studio installations